### PR TITLE
feat(auth): add refresh token rotation with replay-attack detection

### DIFF
--- a/Controllers/AuthController.cs
+++ b/Controllers/AuthController.cs
@@ -1,64 +1,224 @@
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using ToDoApi.DTO;
 using ToDoApi.Models;
-using ToDoApi.Services.Auth;
+using ToDoApi.Repositories.RefreshTokens;
 using ToDoApi.Repositories.Users;
-using Microsoft.AspNetCore.Authorization;
+using ToDoApi.Services.Auth;
 
-namespace ToDoApi.Controllers
+namespace ToDoApi.Controllers;
+
+[ApiController]
+[Route("api/auth")]
+public class AuthController(
+    IUserRepository userRepo,
+    IRefreshTokenRepository refreshTokenRepo,
+    JwtService jwt,
+    ILogger<AuthController> logger) : ControllerBase
 {
-    [ApiController]
-    [Route("api/auth")]
-    public class AuthController : ControllerBase
+    // ────────────────────────────────────────────────────────────────────────────
+    // Register
+    // ────────────────────────────────────────────────────────────────────────────
+
+    [HttpPost("register")]
+    public async Task<IActionResult> Register([FromBody] UserRegisterDto dto)
     {
-        private readonly IUserRepository _repo;
-        private readonly JwtService _jwt;
+        if (await userRepo.ExistsByUsernameAsync(dto.UserName))
+            return Conflict("Username already exists.");
 
-        public AuthController(IUserRepository repo, JwtService jwt)
+        var user = new User
         {
-            _repo = repo;
-            _jwt = jwt;
+            UserName     = dto.UserName,
+            Email        = dto.Email,
+            PasswordHash = BCrypt.Net.BCrypt.HashPassword(dto.Password),
+        };
+
+        await userRepo.AddAsync(user);
+        return Ok(new { Message = "User registered successfully." });
+    }
+
+    // ────────────────────────────────────────────────────────────────────────────
+    // Login
+    // ────────────────────────────────────────────────────────────────────────────
+
+    [HttpPost("login")]
+    public async Task<IActionResult> Login([FromBody] UserLoginDto dto)
+    {
+        var user = await userRepo.GetByUsernameAsync(dto.UserName);
+        if (user is null || !BCrypt.Net.BCrypt.Verify(dto.Password, user.PasswordHash))
+            return Unauthorized("Invalid credentials.");
+
+        var accessToken  = jwt.GenerateToken(user);
+        var refreshToken = jwt.GenerateRefreshToken(user.Id);
+
+        await refreshTokenRepo.AddAsync(refreshToken);
+
+        return Ok(new AuthResponseDto
+        {
+            AccessToken  = accessToken,
+            RefreshToken = refreshToken.Token,
+            UserName     = user.UserName,
+        });
+    }
+
+    // ────────────────────────────────────────────────────────────────────────────
+    // Refresh  —  thread-safe token rotation with replay-attack detection
+    //
+    // Security model (OAuth 2.0 Security BCP §4.14 — Refresh Token Rotation):
+    //   • Every successful refresh issues a NEW access + refresh token pair and
+    //     atomically marks the used refresh token as consumed (IsRevoked=true, UsedAt=now).
+    //   • If a consumed token is presented again it proves the token family has been
+    //     compromised: all active sessions for that user are immediately revoked.
+    //   • Thread safety is achieved with a single atomic SQL UPDATE that only
+    //     matches rows where IsRevoked = false.  Only ONE concurrent request can
+    //     win; all others are detected as replays.
+    //
+    // Grace-Period note (NOT implemented — mention for awareness):
+    //   Frontends that fire N parallel requests on a 401 can legitimately hit this
+    //   endpoint simultaneously with the same token.  A grace-period approach would
+    //   check (UsedAt < now + N seconds) and return a 409 Conflict telling the
+    //   client to back off and retry with the tokens it already received from the
+    //   winning request.  This trades a small security window for better UX.
+    //   The recommended alternative is a client-side refresh mutex (single in-flight
+    //   refresh promise) so the race never reaches the server.
+    // ────────────────────────────────────────────────────────────────────────────
+
+    [HttpPost("refresh")]
+    public async Task<IActionResult> Refresh([FromBody] RefreshTokenRequestDto dto)
+    {
+        // ── 1. Validate access token signature (lifetime is intentionally NOT checked) ──
+        ClaimsPrincipal principal;
+        try
+        {
+            principal = jwt.GetPrincipalFromExpiredToken(dto.AccessToken);
+        }
+        catch
+        {
+            return Unauthorized("Invalid access token.");
         }
 
-        [HttpPost("register")]
-        public async Task<IActionResult> Register([FromBody] UserRegisterDto dto)
-        {
-            if (await _repo.ExistsByUsernameAsync(dto.UserName))
-                return BadRequest("Username already exists.");
+        var userIdClaim = principal.FindFirst(JwtRegisteredClaimNames.Sub)?.Value;
+        if (!int.TryParse(userIdClaim, out var claimedUserId))
+            return Unauthorized("Malformed token claims.");
 
-            var user = new User
+        // ── 2. Load the stored refresh token ────────────────────────────────────
+        var stored = await refreshTokenRepo.GetByTokenAsync(dto.RefreshToken);
+
+        if (stored is null)
+            return Unauthorized("Invalid refresh token.");
+
+        // ── 3. Ownership guard ───────────────────────────────────────────────────
+        // The refresh token's UserId MUST match the Sub claim in the access token.
+        // A mismatch means someone mixed tokens from different accounts — possible
+        // token-confusion attack.  Terminate both users' sessions immediately.
+        if (stored.UserId != claimedUserId)
+        {
+            logger.LogWarning(
+                "Token ownership mismatch: access token Sub={ClaimedUserId}, " +
+                "refresh token owner={TokenUserId}. Revoking all sessions for both users.",
+                claimedUserId, stored.UserId);
+
+            await refreshTokenRepo.RevokeAllForUserAsync(stored.UserId);
+            await refreshTokenRepo.RevokeAllForUserAsync(claimedUserId);
+            return Unauthorized("Token ownership mismatch. All sessions have been terminated.");
+        }
+
+        // ── 4. Classify already-revoked tokens before touching the DB ────────────
+        // UsedAt is non-null ONLY when TryConsumeAsync set it (i.e. this token was
+        // previously rotated).  A revoked token with UsedAt=null was explicitly
+        // logged out via /revoke — that is NOT a replay attack.
+        if (stored.IsRevoked)
+        {
+            if (stored.UsedAt is not null)
             {
-                UserName = dto.UserName,
-                Email = dto.Email,
-                PasswordHash = BCrypt.Net.BCrypt.HashPassword(dto.Password)
-            };
+                logger.LogWarning(
+                    "Replay attack detected for userId={UserId}. " +
+                    "Refresh token was consumed at {UsedAt}. Revoking all active sessions.",
+                    stored.UserId, stored.UsedAt);
 
-            await _repo.AddAsync(user);
+                await refreshTokenRepo.RevokeAllForUserAsync(stored.UserId);
+                return Unauthorized("Refresh token reuse detected. All active sessions have been revoked.");
+            }
 
-            return Ok(new { Message = "User registered successfully." });
+            // Explicitly revoked (logout) — no cascade, just reject.
+            return Unauthorized("Refresh token has been revoked.");
         }
 
-        [HttpPost("login")]
-        public async Task<IActionResult> Login([FromBody] UserLoginDto dto)
+        // ── 5. Expiry check ──────────────────────────────────────────────────────
+        // An expired but not-yet-revoked token is not a security threat;
+        // it just means the user's session aged out naturally.
+        if (stored.IsExpired)
+            return Unauthorized("Refresh token has expired. Please log in again.");
+
+        // ── 6. Atomic claim — the single point of thread safety ─────────────────
+        // Translates to: UPDATE RefreshTokens
+        //                SET    IsRevoked=true, UsedAt=now
+        //                WHERE  Token=@t AND IsRevoked=false
+        //
+        // The database row-level lock ensures exactly one concurrent request
+        // succeeds.  Any other request racing on the same token receives affected=0.
+        var claimed = await refreshTokenRepo.TryConsumeAsync(dto.RefreshToken);
+
+        if (!claimed)
         {
-            var user = await _repo.GetByUsernameAsync(dto.UserName);
-            if (user == null || !BCrypt.Net.BCrypt.Verify(dto.Password, user.PasswordHash))
-                return Unauthorized("Invalid credentials.");
+            // Another request won the race on this token.
+            // Treat as a potential replay: revoke all sessions for this user.
+            //
+            // Grace-period alternative: if (DateTime.UtcNow - stored.UsedAt < GracePeriod)
+            //   return Conflict("Duplicate request detected — use tokens from the first response.");
+            logger.LogWarning(
+                "Concurrent refresh detected for userId={UserId}. " +
+                "Another request already consumed this token. Revoking all active sessions.",
+                stored.UserId);
 
-            var token = _jwt.GenerateToken(user);
-            return Ok(new AuthResponseDto
-            {
-                Token = token,
-                UserName = user.UserName
-            });
+            await refreshTokenRepo.RevokeAllForUserAsync(stored.UserId);
+            return Unauthorized("Concurrent token use detected. All active sessions have been terminated.");
         }
 
-        [Authorize]
-        [HttpGet("me")]
-        public IActionResult Me()
+        // ── 7. Issue new token pair ──────────────────────────────────────────────
+        var user = await userRepo.GetByIdAsync(stored.UserId);
+        if (user is null)
+            return Unauthorized("User account no longer exists.");
+
+        var newAccessToken  = jwt.GenerateToken(user);
+        var newRefreshToken = jwt.GenerateRefreshToken(user.Id);
+        await refreshTokenRepo.AddAsync(newRefreshToken);
+
+        return Ok(new AuthResponseDto
         {
-            var userName = User.Identity?.Name ?? "Unknown";
-            return Ok(new { UserName = userName });
-        }
+            AccessToken  = newAccessToken,
+            RefreshToken = newRefreshToken.Token,
+            UserName     = user.UserName,
+        });
+    }
+
+    // ────────────────────────────────────────────────────────────────────────────
+    // Revoke  (explicit logout)
+    // ────────────────────────────────────────────────────────────────────────────
+
+    [Authorize]
+    [HttpPost("revoke")]
+    public async Task<IActionResult> Revoke([FromBody] RevokeTokenRequestDto dto)
+    {
+        var stored = await refreshTokenRepo.GetByTokenAsync(dto.RefreshToken);
+        if (stored is null || !stored.IsActive)
+            return BadRequest("Refresh token is invalid or already revoked.");
+
+        await refreshTokenRepo.RevokeAsync(stored);
+        return NoContent();
+    }
+
+    // ────────────────────────────────────────────────────────────────────────────
+    // Me
+    // ────────────────────────────────────────────────────────────────────────────
+
+    [Authorize]
+    [HttpGet("me")]
+    public IActionResult Me()
+    {
+        var userName = User.Identity?.Name ?? "Unknown";
+        return Ok(new { UserName = userName });
     }
 }

--- a/DTO/UserDto.cs
+++ b/DTO/UserDto.cs
@@ -25,7 +25,23 @@ namespace ToDoApi.DTO;
 
     public class AuthResponseDto
     {
-        public string Token { get; set; } = string.Empty;
+        public string AccessToken { get; set; } = string.Empty;
+        public string RefreshToken { get; set; } = string.Empty;
         public string UserName { get; set; } = string.Empty;
+    }
+
+    public class RefreshTokenRequestDto
+    {
+        [Required]
+        public string AccessToken { get; set; } = string.Empty;
+
+        [Required]
+        public string RefreshToken { get; set; } = string.Empty;
+    }
+
+    public class RevokeTokenRequestDto
+    {
+        [Required]
+        public string RefreshToken { get; set; } = string.Empty;
     }
 

--- a/Data/AppDbContext.cs
+++ b/Data/AppDbContext.cs
@@ -18,6 +18,7 @@ namespace ToDoApi.Data
 
         public DbSet<Order> Orders { get; set; } = null!;
         public DbSet<Coupon> Coupons { get; set; } = null!;
+        public DbSet<RefreshToken> RefreshTokens { get; set; } = null!;
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
@@ -26,6 +27,16 @@ namespace ToDoApi.Data
                 .WithMany(c => c.Products)
                 .HasForeignKey(p => p.CategoryId)
                 .OnDelete(DeleteBehavior.Cascade);
+
+            modelBuilder.Entity<RefreshToken>()
+                .HasOne(r => r.User)
+                .WithMany()
+                .HasForeignKey(r => r.UserId)
+                .OnDelete(DeleteBehavior.Cascade);
+
+            modelBuilder.Entity<RefreshToken>()
+                .HasIndex(r => r.Token)
+                .IsUnique();
 
             // ProductModel → Product relation
             modelBuilder.Entity<ProductModel>()

--- a/Extensions/IdentityServiceExtensions.cs
+++ b/Extensions/IdentityServiceExtensions.cs
@@ -1,3 +1,4 @@
+using System.IdentityModel.Tokens.Jwt;
 using System.Text;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.IdentityModel.Tokens;
@@ -6,32 +7,21 @@ namespace ToDoApi.Extensions;
 
 public static class IdentityServiceExtensions
 {
-    // Must match the constant in JwtService — single source of truth for the rule.
     private const int MinKeyBytes = 32;
 
     public static IServiceCollection AddIdentityServices(
         this IServiceCollection services,
         IConfiguration config)
     {
-        // ── Guard Clauses ─────────────────────────────────────────────────────
-        // Same validation logic as JwtService.ValidateKey so the app fails fast
-        // at startup rather than at the first token generation attempt.
-
         var keyString = config["Jwt:Key"];
 
         if (string.IsNullOrWhiteSpace(keyString))
             throw new InvalidOperationException(
-                "JWT key is missing or empty. " +
-                "Provide 'Jwt:Key' via environment variables or user secrets — never in appsettings.json.");
+                "JWT key is missing. Provide 'Jwt:Key' via environment variables or user secrets — never in appsettings.json.");
 
         if (Encoding.UTF8.GetByteCount(keyString) < MinKeyBytes)
             throw new InvalidOperationException(
-                $"JWT key is too short. " +
-                $"HMAC-SHA256 requires at least {MinKeyBytes} bytes ({MinKeyBytes * 8} bits).");
-
-        // ── JWT Bearer authentication ─────────────────────────────────────────
-        // IssuerSigningKey, ValidIssuer and ValidAudience intentionally mirror
-        // the values used in JwtService.GenerateToken for consistency.
+                $"JWT key is too short. HMAC-SHA256 requires at least {MinKeyBytes} bytes.");
 
         var signingKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(keyString));
 
@@ -39,6 +29,14 @@ public static class IdentityServiceExtensions
             .AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
             .AddJwtBearer(options =>
             {
+                // Disable the default claim-type remapping that maps
+                //   "sub"         → ClaimTypes.NameIdentifier
+                //   "unique_name" → ClaimTypes.Name
+                //   etc.
+                // With this set to false, claims keep their original JWT names,
+                // so FindFirst(JwtRegisteredClaimNames.Sub) works as expected.
+                options.MapInboundClaims = false;
+
                 options.TokenValidationParameters = new TokenValidationParameters
                 {
                     ValidateIssuer           = true,
@@ -50,11 +48,12 @@ public static class IdentityServiceExtensions
                     ValidAudience    = config["Jwt:Audience"],
                     IssuerSigningKey = signingKey,
 
-                    // Claims created in JwtService use "Role" — must match here.
+                    // Tell ASP.NET Core which raw JWT claim to use for
+                    // User.Identity.Name and [Authorize(Roles=...)] checks.
+                    NameClaimType = JwtRegisteredClaimNames.UniqueName, // "unique_name"
                     RoleClaimType = "Role",
 
-                    // No tolerance for expired tokens.
-                    ClockSkew = TimeSpan.Zero
+                    ClockSkew = TimeSpan.Zero,
                 };
             });
 

--- a/Extensions/ServiceExtensions.cs
+++ b/Extensions/ServiceExtensions.cs
@@ -5,6 +5,7 @@ using ToDoApi.Infrastructure.Storage;
 using ToDoApi.Repositories;
 using ToDoApi.Repositories.Categories;
 using ToDoApi.Repositories.Products;
+using ToDoApi.Repositories.RefreshTokens;
 using ToDoApi.Repositories.Users;
 using ToDoApi.Services.Auth;
 using ToDoApi.Services.Categories;
@@ -33,6 +34,7 @@ public static class ServiceExtensions
         services.AddScoped<IProductRepository, ProductRepository>();
         services.AddScoped<ICategoryRepository, CategoryRepository>();
         services.AddScoped<IUserRepository, UserRepository>();
+        services.AddScoped<IRefreshTokenRepository, RefreshTokenRepository>();
 
         // ── Domain services ───────────────────────────────────────────────────
 

--- a/Infrastructure/Storage/IBookStore.cs
+++ b/Infrastructure/Storage/IBookStore.cs
@@ -1,7 +1,7 @@
 using ToDoApi.Domain;
 
-namespace ToDoApi.Infrastructure.Storage
-{
+namespace ToDoApi.Infrastructure.Storage;
+
     public interface IBookStore
     {
         IEnumerable<Book> GetAll();
@@ -10,4 +10,3 @@ namespace ToDoApi.Infrastructure.Storage
         bool Update(int id, Book book);
         bool Delete(int id);
     }
-}

--- a/Migrations/20260628120453_AddRefreshTokens.Designer.cs
+++ b/Migrations/20260628120453_AddRefreshTokens.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using ToDoApi.Data;
@@ -11,9 +12,11 @@ using ToDoApi.Data;
 namespace ToDoApi.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260628120453_AddRefreshTokens")]
+    partial class AddRefreshTokens
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -265,9 +268,6 @@ namespace ToDoApi.Migrations
                     b.Property<string>("Token")
                         .IsRequired()
                         .HasColumnType("text");
-
-                    b.Property<DateTime?>("UsedAt")
-                        .HasColumnType("timestamp with time zone");
 
                     b.Property<int>("UserId")
                         .HasColumnType("integer");

--- a/Migrations/20260628120453_AddRefreshTokens.cs
+++ b/Migrations/20260628120453_AddRefreshTokens.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+#nullable disable
+
+namespace ToDoApi.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddRefreshTokens : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "RefreshTokens",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    Token = table.Column<string>(type: "text", nullable: false),
+                    ExpiresAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    IsRevoked = table.Column<bool>(type: "boolean", nullable: false),
+                    UserId = table.Column<int>(type: "integer", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_RefreshTokens", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_RefreshTokens_Users_UserId",
+                        column: x => x.UserId,
+                        principalTable: "Users",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_RefreshTokens_Token",
+                table: "RefreshTokens",
+                column: "Token",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_RefreshTokens_UserId",
+                table: "RefreshTokens",
+                column: "UserId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "RefreshTokens");
+        }
+    }
+}

--- a/Migrations/20260628121957_AddRefreshTokenUsedAt.Designer.cs
+++ b/Migrations/20260628121957_AddRefreshTokenUsedAt.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using ToDoApi.Data;
@@ -11,9 +12,11 @@ using ToDoApi.Data;
 namespace ToDoApi.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260628121957_AddRefreshTokenUsedAt")]
+    partial class AddRefreshTokenUsedAt
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Migrations/20260628121957_AddRefreshTokenUsedAt.cs
+++ b/Migrations/20260628121957_AddRefreshTokenUsedAt.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace ToDoApi.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddRefreshTokenUsedAt : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateTime>(
+                name: "UsedAt",
+                table: "RefreshTokens",
+                type: "timestamp with time zone",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "UsedAt",
+                table: "RefreshTokens");
+        }
+    }
+}

--- a/Models/RefreshToken.cs
+++ b/Models/RefreshToken.cs
@@ -1,0 +1,21 @@
+namespace ToDoApi.Models;
+
+public class RefreshToken
+{
+    public int Id { get; set; }
+    public string Token { get; set; } = string.Empty;
+    public DateTime ExpiresAt { get; set; }
+    public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+
+    // Set atomically only when consumed via /refresh (never via /revoke).
+    // null  → token was explicitly revoked (logout) or is still active.
+    // !null → token was consumed in a prior Refresh call; reuse = replay attack.
+    public DateTime? UsedAt { get; set; }
+
+    public bool IsRevoked { get; set; }
+    public int UserId { get; set; }
+    public User User { get; set; } = null!;
+
+    public bool IsExpired => DateTime.UtcNow >= ExpiresAt;
+    public bool IsActive => !IsRevoked && !IsExpired;
+}

--- a/Program.cs
+++ b/Program.cs
@@ -1,54 +1,83 @@
-﻿using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.OpenApi.Models;
 using ToDoApi.Data;
 using ToDoApi.Extensions;
 
 var builder = WebApplication.CreateBuilder(args);
 
-// 1. SERVICES CONFIGURATION (Dependency Injection)
+// ── Controllers ───────────────────────────────────────────────────────────────
 builder.Services.AddControllers()
     .AddJsonOptions(opt =>
     {
         opt.JsonSerializerOptions.ReferenceHandler = System.Text.Json.Serialization.ReferenceHandler.IgnoreCycles;
-        opt.JsonSerializerOptions.WriteIndented = true;
+        opt.JsonSerializerOptions.WriteIndented    = true;
     });
 
-// Swagger/OpenAPI
+// ── Swagger ───────────────────────────────────────────────────────────────────
 builder.Services.AddEndpointsApiExplorer();
-builder.Services.AddSwaggerGen();
+builder.Services.AddSwaggerGen(options =>
+{
+    options.SwaggerDoc("v1", new OpenApiInfo { Title = "ToDoApi", Version = "v1" });
 
-// Database (PostgreSQL)
+    // Adds the padlock button and "Authorize" dialog to the Swagger UI.
+    var bearerScheme = new OpenApiSecurityScheme
+    {
+        Name         = "Authorization",
+        Type         = SecuritySchemeType.Http,
+        Scheme       = "Bearer",
+        BearerFormat = "JWT",
+        In           = ParameterLocation.Header,
+        Description  = "Paste your JWT access token here. It is sent as: Authorization: Bearer {token}",
+    };
+
+    options.AddSecurityDefinition("Bearer", bearerScheme);
+
+    options.AddSecurityRequirement(new OpenApiSecurityRequirement
+    {
+        {
+            new OpenApiSecurityScheme
+            {
+                Reference = new OpenApiReference
+                {
+                    Type = ReferenceType.SecurityScheme,
+                    Id   = "Bearer",
+                }
+            },
+            Array.Empty<string>()
+        }
+    });
+});
+
+// ── Database ──────────────────────────────────────────────────────────────────
 builder.Services.AddDbContext<AppDbContext>(options =>
     options.UseNpgsql(builder.Configuration.GetConnectionString("DefaultConnection")));
 
-// Custom Application & Identity Extensions
+// ── Application services & JWT auth ──────────────────────────────────────────
 builder.Services.AddApplicationServices();
 builder.Services.AddIdentityServices(builder.Configuration);
 
 builder.Services.AddHealthChecks()
     .AddDbContextCheck<AppDbContext>();
 
+// ── Middleware pipeline ───────────────────────────────────────────────────────
 var app = builder.Build();
 
-// 2. MIDDLEWARE PIPELINE 
 app.UseErrorHandling();
 
-// Swagger
 if (app.Environment.IsDevelopment())
 {
     app.UseSwagger();
     app.UseSwaggerUI(c =>
     {
-        c.SwaggerEndpoint("/swagger/v1/swagger.json", "My Project API V1");
+        c.SwaggerEndpoint("/swagger/v1/swagger.json", "ToDoApi V1");
         c.RoutePrefix = string.Empty;
     });
 }
 
 app.UseRouting();
-
 app.UseAuthentication();
 app.UseAuthorization();
 
-// ENDPOINTS & CONTROLLERS MAPPING
 app.MapHealthChecks("/health");
 app.MapAllEndpoints();
 app.MapControllers();

--- a/Repositories/RefreshTokens/IRefreshTokenRepository.cs
+++ b/Repositories/RefreshTokens/IRefreshTokenRepository.cs
@@ -1,0 +1,16 @@
+using ToDoApi.Models;
+
+namespace ToDoApi.Repositories.RefreshTokens;
+
+public interface IRefreshTokenRepository
+{
+    Task<RefreshToken?> GetByTokenAsync(string token);
+    Task AddAsync(RefreshToken refreshToken);
+
+    // Atomically marks the token as consumed (IsRevoked=true, UsedAt=now).
+    // Returns true if the claim succeeded, false if already revoked (race condition / replay).
+    Task<bool> TryConsumeAsync(string token);
+
+    Task RevokeAsync(RefreshToken refreshToken);
+    Task RevokeAllForUserAsync(int userId);
+}

--- a/Repositories/RefreshTokens/RefreshTokenRepository.cs
+++ b/Repositories/RefreshTokens/RefreshTokenRepository.cs
@@ -1,0 +1,50 @@
+using Microsoft.EntityFrameworkCore;
+using ToDoApi.Data;
+using ToDoApi.Models;
+
+namespace ToDoApi.Repositories.RefreshTokens;
+
+public class RefreshTokenRepository(AppDbContext context) : IRefreshTokenRepository
+{
+    public async Task<RefreshToken?> GetByTokenAsync(string token) =>
+        await context.RefreshTokens
+            .AsNoTracking()
+            .FirstOrDefaultAsync(r => r.Token == token);
+
+    public async Task AddAsync(RefreshToken refreshToken)
+    {
+        context.RefreshTokens.Add(refreshToken);
+        await context.SaveChangesAsync();
+    }
+
+    // Single atomic UPDATE … WHERE Token = @t AND IsRevoked = false.
+    // The database serializes concurrent writes to the same row, so exactly one
+    // caller will receive affected = 1; all racing duplicates receive affected = 0.
+    public async Task<bool> TryConsumeAsync(string token)
+    {
+        var now = DateTime.UtcNow;
+        var affected = await context.RefreshTokens
+            .Where(r => r.Token == token && !r.IsRevoked)
+            .ExecuteUpdateAsync(s => s
+                .SetProperty(r => r.IsRevoked, true)
+                .SetProperty(r => r.UsedAt, now));
+
+        return affected > 0;
+    }
+
+    // Used only by /revoke (explicit logout). Does NOT set UsedAt, so
+    // the controller can distinguish logout from replay on a reuse attempt.
+    public async Task RevokeAsync(RefreshToken refreshToken)
+    {
+        await context.RefreshTokens
+            .Where(r => r.Id == refreshToken.Id && !r.IsRevoked)
+            .ExecuteUpdateAsync(s => s.SetProperty(r => r.IsRevoked, true));
+    }
+
+    public async Task RevokeAllForUserAsync(int userId)
+    {
+        await context.RefreshTokens
+            .Where(r => r.UserId == userId && !r.IsRevoked)
+            .ExecuteUpdateAsync(s => s.SetProperty(r => r.IsRevoked, true));
+    }
+}

--- a/Repositories/Users/IUserRepository.cs
+++ b/Repositories/Users/IUserRepository.cs
@@ -4,6 +4,7 @@ namespace ToDoApi.Repositories.Users
 {
     public interface IUserRepository
     {
+        Task<User?> GetByIdAsync(int id);
         Task<User?> GetByUsernameAsync(string username);
         Task<bool> ExistsByUsernameAsync(string username);
         Task<User> AddAsync(User user);

--- a/Repositories/Users/UserRepository.cs
+++ b/Repositories/Users/UserRepository.cs
@@ -13,6 +13,9 @@ namespace ToDoApi.Repositories.Users
             _context = context;
         }
 
+        public async Task<User?> GetByIdAsync(int id) =>
+            await _context.Users.FindAsync(id);
+
         public async Task<User?> GetByUsernameAsync(string username) =>
             await _context.Users.FirstOrDefaultAsync(u => u.UserName == username);
 

--- a/Services/Auth/JwtService.cs
+++ b/Services/Auth/JwtService.cs
@@ -1,5 +1,6 @@
 using System.IdentityModel.Tokens.Jwt;
 using System.Security.Claims;
+using System.Security.Cryptography;
 using System.Text;
 using Microsoft.Extensions.Configuration;
 using Microsoft.IdentityModel.Tokens;
@@ -11,11 +12,12 @@ public sealed class JwtService(IConfiguration config, TimeProvider? timeProvider
 {
     private const int MinKeyBytes = 32;
 
-    private readonly string       _key         = ValidateKey(config["Jwt:Key"]);
-    private readonly string       _issuer      = config["Jwt:Issuer"]   ?? string.Empty;
-    private readonly string       _audience    = config["Jwt:Audience"] ?? string.Empty;
-    private readonly int          _expiryHours = int.TryParse(config["Jwt:ExpireHours"], out var h) ? h : 2;
-    private readonly TimeProvider _time        = timeProvider ?? TimeProvider.System;
+    private readonly string       _key                = ValidateKey(config["Jwt:Key"]);
+    private readonly string       _issuer             = config["Jwt:Issuer"]          ?? string.Empty;
+    private readonly string       _audience           = config["Jwt:Audience"]        ?? string.Empty;
+    private readonly int          _expiryHours        = int.TryParse(config["Jwt:ExpireHours"],       out var h) ? h : 2;
+    private readonly int          _refreshExpiryDays  = int.TryParse(config["Jwt:RefreshExpireDays"], out var d) ? d : 7;
+    private readonly TimeProvider _time               = timeProvider ?? TimeProvider.System;
 
     public string GenerateToken(User user)
     {
@@ -42,6 +44,49 @@ public sealed class JwtService(IConfiguration config, TimeProvider? timeProvider
             signingCredentials: credentials);
 
         return new JwtSecurityTokenHandler().WriteToken(token);
+    }
+
+    public RefreshToken GenerateRefreshToken(int userId)
+    {
+        Span<byte> bytes = stackalloc byte[64];
+        RandomNumberGenerator.Fill(bytes);
+
+        return new RefreshToken
+        {
+            Token     = Convert.ToBase64String(bytes),
+            UserId    = userId,
+            ExpiresAt = _time.GetUtcNow().UtcDateTime.AddDays(_refreshExpiryDays),
+            CreatedAt = _time.GetUtcNow().UtcDateTime,
+        };
+    }
+
+    public ClaimsPrincipal GetPrincipalFromExpiredToken(string token)
+    {
+        var validationParams = new TokenValidationParameters
+        {
+            ValidateIssuer           = true,
+            ValidateAudience         = true,
+            ValidateLifetime         = false, // intentionally skipped — token may be expired
+            ValidateIssuerSigningKey = true,
+            ValidIssuer              = _issuer,
+            ValidAudience            = _audience,
+            IssuerSigningKey         = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(_key)),
+        };
+
+        var handler = new JwtSecurityTokenHandler();
+
+        // Mirrors the MapInboundClaims = false setting in IdentityServiceExtensions.
+        // Without this, "sub" is silently remapped to ClaimTypes.NameIdentifier,
+        // causing FindFirst(JwtRegisteredClaimNames.Sub) to return null.
+        handler.InboundClaimTypeMap.Clear();
+
+        var principal = handler.ValidateToken(token, validationParams, out var validated);
+
+        if (validated is not JwtSecurityToken jwt ||
+            !jwt.Header.Alg.Equals(SecurityAlgorithms.HmacSha256, StringComparison.OrdinalIgnoreCase))
+            throw new SecurityTokenException("Invalid token algorithm.");
+
+        return principal;
     }
 
     // Static helper: can be called from a field initializer (no `this` needed).


### PR DESCRIPTION
Replace single JWT access token with an access+refresh token pair. Refresh tokens are single-use: each /refresh call atomically consumes the old token and issues a new pair, and reuse of an already-consumed token revokes all active sessions for that user.

- Add RefreshToken model, repository, and EF migrations
- JwtService: generate cryptographically random refresh tokens and validate expired access tokens for the refresh flow
- AuthController: /refresh (rotation + ownership/replay checks) and /revoke (logout) endpoints
- IdentityServiceExtensions: disable inbound claim remapping so Sub claim is usable directly
- Program.cs: add Bearer auth support to Swagger UI